### PR TITLE
Change translation wording to match with K2

### DIFF
--- a/locale/ja/zirconium.cfg
+++ b/locale/ja/zirconium.cfg
@@ -42,7 +42,7 @@ zirconia=__ITEM__zirconia__
 zirconium-plate=__ITEM__zirconium-plate__
 smelt-compressed-zircon=__ITEM__zirconia__
 zircon-dust=__ITEM__zircon-dust__
-dirty-water-filtration-zircon=汚水分離[item=zircon]
+dirty-water-filtration-zircon=汚水をろ過[item=zircon]
 
 [recipe-description]
 enriched-zircon=ジルコンを硫酸[fluid=sulfuric-acid] と水[fluid=water] で処理し、収量を改善します。副産物として汚水[fluid=dirty-water] を生産します。


### PR DESCRIPTION
This PR updates ja translation of dirty-water-filtration-zircon to match with K2's existing recipes.
